### PR TITLE
feat: Add plant diagnosis tool using video stream

### DIFF
--- a/agent_config.py
+++ b/agent_config.py
@@ -50,6 +50,7 @@ from proactive_agents import (
 # Import the Google Search Agent
 from google_search_agent.agent import root_agent as google_search_agent_instance
 # Import the PubMed query function directly
+from tools.aura_client import diagnose_plant_from_video_feed
 from tools.chart_tool import generate_simple_bar_chart, generate_simple_line_chart, generate_pie_chart, generate_grouped_bar_chart # UPDATED IMPORT
 from clinical_trials_pipeline import query_clinical_trials_data # New Import
 from pubmed_pipeline import query_pubmed_articles, get_publication_trend
@@ -80,8 +81,9 @@ Role: You are AVA (Advanced Visual Assistant), a multimodal AI. Your goal is to 
 2.  **Memory Recall (If explicitly asked):**
     *   If the user asks you to "remember" something, asks "what do you know about me?", or refers to a past conversation beyond the immediate recent turns, you **MUST** use the `DeepMemoryRecallAgent` to search your long-term memory.
 
-2.  **Visual Scene Analysis (Multimodal Perception)**:
+3.  **Visual Scene Analysis (Multimodal Perception)**:
     *   Analyze incoming video frames to identify relevant objects ('seen_items') and infer context ('initial_context_keywords').
+    *   **Plant Diagnosis**: If you identify a plant in the video feed, you can proactively ask the user if they would like a health diagnosis. If they agree, or if they ask you to "diagnose the plant" or a similar query, you **MUST** use the `diagnose_plant_from_video_feed` tool.
 
 3.  **Emotional Context Analysis (If video/audio is active):**
     *   You **MUST** call the `EmotionalSynthesizerAgent` tool. **Crucially, you must pass it the user's transcribed text.** Example: `EmotionalSynthesizerAgent(transcribed_text="I'm doing great today.")`. This tool analyzes facial expressions, vocal tone, and the provided text to create an overall emotional context.
@@ -906,7 +908,7 @@ def create_streaming_agent_with_mcp_tools(
         ],
        "after_model_callback": save_interaction_after_model_callback,
     }
-    all_root_agent_tools: List[Any] = []
+    all_root_agent_tools: List[Any] = [diagnose_plant_from_video_feed]
 
     if loaded_mcp_toolsets:
         all_root_agent_tools.extend(loaded_mcp_toolsets)

--- a/static/uploads/.gitignore
+++ b/static/uploads/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all files in this directory
+*
+
+# Except for this .gitignore file
+!.gitignore

--- a/tools/aura_client.py
+++ b/tools/aura_client.py
@@ -2,10 +2,57 @@ import os
 import time
 import logging
 import asyncio
+import uuid
 from gradio_client import Client, handle_file
+from google.adk.tools.tool_context import ToolContext
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+async def diagnose_plant_from_video_feed(tool_context: ToolContext) -> str:
+    """
+    Retrieves the latest video frame from the session, saves it as a temporary file,
+    and sends it for diagnosis.
+
+    Args:
+        tool_context: The context of the tool call, containing session state.
+
+    Returns:
+        The diagnosis text from the server, or an error message.
+    """
+    logging.info("Attempting to diagnose plant from video feed.")
+    image_bytes = tool_context._invocation_context.session.state.get('latest_image_bytes')
+
+    if not image_bytes:
+        logging.warning("Diagnose tool called, but no image was found in the session context.")
+        return "I am sorry, I could not see an image to diagnose. Please ensure your video is active."
+
+    # Create a unique filename for the temporary image
+    temp_dir = "static/uploads"
+    if not os.path.exists(temp_dir):
+        os.makedirs(temp_dir)
+
+    temp_filename = f"{uuid.uuid4()}.jpg"
+    temp_filepath = os.path.join(temp_dir, temp_filename)
+
+    try:
+        # Save the image bytes to the temporary file
+        with open(temp_filepath, 'wb') as f:
+            f.write(image_bytes)
+        logging.info(f"Saved latest video frame to temporary file: {temp_filepath}")
+
+        # Call the diagnosis function with the new image path
+        diagnosis = await diagnose_plant_from_huggingface(temp_filepath)
+        return diagnosis if diagnosis else "Failed to get a diagnosis."
+
+    except Exception as e:
+        logging.error(f"Error saving or diagnosing image from video feed: {e}", exc_info=True)
+        return "I encountered an error while processing the image from the video feed."
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_filepath):
+            os.remove(temp_filepath)
+            logging.info(f"Removed temporary file: {temp_filepath}")
 
 async def diagnose_plant_from_huggingface(image_path_on_server: str) -> str | None:
     """


### PR DESCRIPTION
This commit introduces a new capability for the agent to diagnose plant health directly from the live video feed.

A new tool, `diagnose_plant_from_video_feed`, has been added to `tools/aura_client.py`. This tool retrieves the latest video frame from the session state, saves it as a temporary image, and passes it to the existing Hugging Face diagnosis service.

The agent's configuration in `agent_config.py` has been updated to include this new tool. The root agent's instructions have also been modified to enable it to proactively offer a diagnosis when a plant is detected in the video stream and to use the tool when requested by the user.

A `static/uploads` directory has been created to store temporary images, with a `.gitignore` file to prevent these images from being committed to the repository.