### PR TITLE
feat: Add Nano Banana image generation tool

### DIFF
--- a/agent_config.py
+++ b/agent_config.py
@@ -50,6 +50,7 @@ from proactive_agents import (
 from google_search_agent.agent import root_agent as google_search_agent_instance
 # Import the PubMed query function directly
 from tools.aura_client import diagnose_plant_tool
+from tools.nanobana_tool import generate_image_with_nanobana
 from tools.chart_tool import generate_simple_bar_chart, generate_simple_line_chart, generate_pie_chart, generate_grouped_bar_chart # UPDATED IMPORT
 from clinical_trials_pipeline import query_clinical_trials_data # New Import
 from pubmed_pipeline import query_pubmed_articles, get_publication_trend
@@ -149,7 +150,11 @@ Role: You are AVA (Advanced Visual Assistant), a multimodal AI. Your goal is to 
         1.  You **MUST** call the `PlantDiagnosisAgent` to perform the diagnosis.
     *   The direct output from the `PlantDiagnosisAgent` will be your final answer to the user. Do not modify or add to it.
 
-16. **Response Formatting**: Always format your final response to the user using Markdown for enhanced readability. If the response is derived from a tool, present that agent's findings clearly.
+16. **Delegation for Image Generation**:
+    *   **IF** the user asks to "generate an image", "create a picture of", or other similar creative requests, you **MUST** delegate the task to the `ImageGenerationAgent`.
+    *   The direct output from the `ImageGenerationAgent` will be the URL of the newly created image. You should present this to the user, for example, by saying "Here is the image I created for you:" followed by the URL.
+
+17. **Response Formatting**: Always format your final response to the user using Markdown for enhanced readability. If the response is derived from a tool, present that agent's findings clearly.
 
 
 
@@ -899,6 +904,15 @@ PLANT_DIAGNOSIS_AGENT_INSTRUCTION = '''
 You are a plant diagnosis agent. When asked to diagnose a plant, you must use the `diagnose_plant_tool`.
 '''
 
+IMAGE_GENERATION_AGENT_INSTRUCTION = """
+You are a specialized Image Generation Agent. Your sole purpose is to take a user's text prompt and use the `generate_image_with_nanobana` tool to create an image.
+
+**--- Core Workflow ---**
+1.  Take the user's request which is a text description of an image.
+2.  Call the `generate_image_with_nanobana` tool with the user's prompt.
+3.  Return ONLY the URL of the generated image. Do not add any conversational text or acknowledgements.
+"""
+
 def create_streaming_agent_with_mcp_tools(
     loaded_mcp_toolsets: List[MCPToolset],
     #raw_mcp_tools_lookup_for_warnings: Dict[str, Any] # No longer strictly needed here
@@ -1295,6 +1309,21 @@ To cite a source, you **MUST** insert a special citation tag directly after the 
 
     all_root_agent_tools.append(plant_diagnosis_agent_tool)
     logging.info(f"PlantDiagnosisAgent wrapped as AgentTool ('{plant_diagnosis_agent_tool.name}') and added to Root Agent's tools.")
+
+    image_generation_agent = LlmAgent(
+        model=GEMINI_PRO_MODEL_ID,
+        name="ImageGenerationAgent",
+        instruction=IMAGE_GENERATION_AGENT_INSTRUCTION,
+        tools=[generate_image_with_nanobana],
+        **shared_callbacks
+    )
+    logging.info(f"ImageGenerationAgent instance created: {image_generation_agent.name}")
+
+    image_generation_agent_tool = AgentTool(agent=image_generation_agent)
+    if hasattr(image_generation_agent_tool, 'run_async'):
+        image_generation_agent_tool.func = image_generation_agent_tool.run_async
+    all_root_agent_tools.append(image_generation_agent_tool)
+    logging.info("ImageGenerationAgent wrapped as a tool and added to Root Agent's tools.")
 
     # Agent A: The Narrative Writer
     text_synthesizer_agent = LlmAgent(

--- a/tools/nanobana_tool.py
+++ b/tools/nanobana_tool.py
@@ -1,0 +1,92 @@
+# /Users/surfiniaburger/Desktop/app/tools/nanobana_tool.py
+import logging
+import os
+import uuid
+from typing import Optional
+import google.generativeai as genai
+from google.generativeai import types
+import PIL.Image
+import io
+
+logger = logging.getLogger(__name__)
+
+# --- Configuration ---
+# Ensure the directory for generated images exists
+STATIC_UPLOADS_DIR = "static/uploads"
+os.makedirs(STATIC_UPLOADS_DIR, exist_ok=True)
+
+# It's recommended to set the API key as an environment variable for security
+# e.g., export GOOGLE_API_KEY="your_api_key_here"
+try:
+    GOOGLE_API_KEY = os.environ.get('GOOGLE_API_KEY')
+    if not GOOGLE_API_KEY:
+        raise ValueError("GOOGLE_API_KEY environment variable not set.")
+    genai.configure(api_key=GOOGLE_API_KEY)
+except Exception as e:
+    logger.error(f"Failed to configure Google GenAI: {e}")
+    # Handle the case where the API key is not set.
+    # The tool will fail gracefully if the key is missing.
+
+MODEL_ID = "gemini-2.5-flash-image-preview"
+
+def generate_image_with_nanobana(
+    prompt: str,
+) -> Optional[str]:
+    """
+    Generates an image based on a text prompt using the Gemini 1.5 Flash model.
+
+    Args:
+        prompt: The text prompt describing the image to generate.
+
+    Returns:
+        The relative web URL of the saved image (e.g., "/static/uploads/image_uuid.png"),
+        or None if an error occurs.
+    """
+    if not prompt:
+        logger.warning("Nano Banana tool was called with an empty prompt.")
+        return None
+
+    if not GOOGLE_API_KEY:
+        logger.error("Cannot generate image: GOOGLE_API_KEY is not configured.")
+        return "Error: Image generation API key is not configured."
+
+    try:
+        logger.info(f"Generating image with Gemini 1.5 for prompt: '{prompt}'")
+
+        # Initialize the client within the function if you expect the key to be
+        # managed in a dynamic environment, or rely on the module-level configuration.
+        client = genai.GenerativeModel(MODEL_ID)
+
+        # Generate the content
+        response = client.generate_content(
+            contents=prompt,
+            generation_config=types.GenerationConfig(
+                response_mime_type='image/png' # Request a PNG image directly
+            )
+        )
+
+        # Process the response to find and save the image
+        for part in response.parts:
+            if part.inline_data:
+                # The response contains the image bytes directly
+                image_bytes = part.inline_data.data
+
+                # Create a PIL Image object from the bytes
+                image = PIL.Image.open(io.BytesIO(image_bytes))
+
+                # Save the image with a unique filename
+                filename = f"image_{uuid.uuid4().hex}.png"
+                filepath = os.path.join(STATIC_UPLOADS_DIR, filename)
+                image.save(filepath)
+
+                # Return the web-accessible URL
+                web_url = f"/{STATIC_UPLOADS_DIR}/{filename}"
+                logger.info(f"Image successfully generated and saved to {filepath}")
+                return web_url
+
+        logger.warning("Image generation call succeeded but no image data was returned.")
+        return "No image could be generated for that prompt."
+
+    except Exception as e:
+        logger.error(f"Error in Gemini image generation tool: {e}", exc_info=True)
+        return f"An error occurred during image generation: {e}"


### PR DESCRIPTION
This commit integrates the Nano Banana (Gemini 2.5) image generation tool into the agent application.

A new tool `tools/nanobana_tool.py` has been created to handle the image generation logic using the `google-generativeai` library. This tool takes a text prompt, generates an image, saves it to the `static/uploads` directory, and returns a web-accessible URL.

A new `ImageGenerationAgent` has been defined in `agent_config.py` to use this tool. This agent is then integrated into the root agent's workflow, allowing the user to request image generation with prompts like "generate an image of...".

The root agent's instructions have been updated to delegate image generation tasks to the new agent.